### PR TITLE
feat: add card deck utility

### DIFF
--- a/src/deck.js
+++ b/src/deck.js
@@ -1,0 +1,35 @@
+const SUITS = ['hearts', 'diamonds', 'clubs', 'spades'];
+const RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+function createDeck() {
+  const deck = [];
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      deck.push({ rank, suit });
+    }
+  }
+  return deck;
+}
+
+function shuffle(deck) {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+  return deck;
+}
+
+function draw(deck) {
+  return deck.pop();
+}
+
+function discard(card, pile) {
+  pile.push(card);
+}
+
+module.exports = {
+  createDeck,
+  shuffle,
+  draw,
+  discard,
+};


### PR DESCRIPTION
## Summary
- add deck helper with create, shuffle, draw and discard functions

## Testing
- `node -e "const d=require('./src/deck');const deck=d.createDeck();d.shuffle(deck);const drawn=d.draw(deck);const pile=[];d.discard(drawn,pile);console.log(deck.length,pile.length);"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9766b370832f9ebe066e6a77eb6d