### PR TITLE
Add basic UI with touch/click controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Thirty-One</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    body {
+      font-family: sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 0;
+      padding: 1rem;
+    }
+    #play-area {
+      display: flex;
+      gap: 1rem;
+      margin: 1rem 0;
+    }
+    #deck,
+    #discard,
+    #hand {
+      border: 1px solid #333;
+      padding: 1rem;
+      min-width: 80px;
+      min-height: 120px;
+      display: flex;
+      flex-wrap: wrap;
+    }
+    .card {
+      border: 1px solid #666;
+      padding: 0.25rem;
+      margin: 0.25rem;
+      cursor: pointer;
+      user-select: none;
+    }
+    #controls {
+      margin-top: 1rem;
+    }
+    button {
+      margin: 0 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>Thirty-One</h1>
+  <div id="play-area">
+    <div id="deck">Deck</div>
+    <div id="discard">Discard</div>
+  </div>
+  <div id="hand">Hand</div>
+  <div id="controls">
+    <button id="knock">Knock</button>
+    <button id="pass">Pass</button>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,57 @@
+const deckEl = document.getElementById('deck');
+const discardEl = document.getElementById('discard');
+const handEl = document.getElementById('hand');
+const knockBtn = document.getElementById('knock');
+const passBtn = document.getElementById('pass');
+
+// simple representation of cards
+const deck = ['A\u2660', '2\u2660', '3\u2660', '4\u2660', '5\u2660'];
+const hand = [];
+const discard = [];
+
+function bindPointer(element, handler) {
+  ['click', 'touchstart'].forEach(evt =>
+    element.addEventListener(evt, e => {
+      e.preventDefault();
+      handler();
+    })
+  );
+}
+
+function updateUI() {
+  deckEl.textContent = `Deck (${deck.length})`;
+  discardEl.textContent = discard.length ? discard[discard.length - 1] : 'Discard';
+  handEl.innerHTML = '';
+  hand.forEach((card, index) => {
+    const cardEl = document.createElement('div');
+    cardEl.textContent = card;
+    cardEl.className = 'card';
+    bindPointer(cardEl, () => discardCard(index));
+    handEl.appendChild(cardEl);
+  });
+}
+
+function drawCard() {
+  if (!deck.length) return;
+  hand.push(deck.pop());
+  updateUI();
+}
+
+function discardCard(index) {
+  discard.push(hand.splice(index, 1)[0]);
+  updateUI();
+}
+
+function knock() {
+  console.log('Knock');
+}
+
+function pass() {
+  console.log('Pass');
+}
+
+bindPointer(deckEl, drawCard);
+bindPointer(knockBtn, knock);
+bindPointer(passBtn, pass);
+
+updateUI();


### PR DESCRIPTION
## Summary
- Add simple HTML layout for Thirty-One with deck, discard, hand, and action buttons
- Implement JavaScript to map click/touch events for drawing from deck, discarding from hand, and action buttons

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad976a6e88832f8704135e3836dbe3